### PR TITLE
Make "network"-name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ module "gci_test" {
   region       = "us-east1"
   name_prefix  = "test"
   machine_type = "custom-2-2048"
+  network      = "mynetwork"
   disk_size    = "32"
   disk_image   = "${data.google_compute_image.coreos_stable.self_link}"
 }

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ resource "google_compute_instance" "instances" {
   }
 
   network_interface = {
-    network = "default"
+    network = "${var.network}"
 
     access_config = {
       nat_ip = "${google_compute_address.instances.*.address[count.index]}"

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,10 @@ variable "name_prefix" {}
 variable "machine_type" {}
 variable "user_data" {}
 
+variable "network" {
+  default = "default"
+}
+
 variable "disk_type" {
   default = "pd-ssd"
 }


### PR DESCRIPTION
There may be projects where "default" may not be the only network.